### PR TITLE
Update to allow compiling with current go versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.11 as builder
+FROM golang:1.16 as builder
 WORKDIR /src/github.com/devinotelecom/prometheus-vmware-exporter
 COPY ./ /src/github.com/devinotelecom/prometheus-vmware-exporter
 RUN go get -d -v
 RUN CGO_ENABLED=0 GOOS=linux go build
 
-FROM alpine:3.8
+FROM alpine:3.14
 COPY --from=builder /src/github.com/devinotelecom/prometheus-vmware-exporter/prometheus-vmware-exporter /usr/bin/prometheus-vmware-exporter
 EXPOSE 9512
 ENTRYPOINT ["prometheus-vmware-exporter"]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+go 1.16
+
+module prometheus-vmware-exporter

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"./controller"
+	"prometheus-vmware-exporter/controller"
 	"flag"
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus/promhttp"


### PR DESCRIPTION
Syntax for importing local modules has changed in golang, so cannot
cannot import "./controller" anymore.